### PR TITLE
Update OSErrorMsg usage due to nimrod 0.9.4 deprecation

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -102,7 +102,7 @@ proc statusContent(c: TSocket, status, content: string, headers: PStringTable, h
   if sent:
     echo("  ", status, " ", headers)
   else:
-    echo("Could not send response: ", OSErrorMsg())
+    echo("Could not send response: ", OSErrorMsg(OSLastError()))
   
 proc `$`*(r: TRegexMatch): string = return r.original
 


### PR DESCRIPTION
This is a change to resolve this warning message.

```
.../jester.nim(105, 38) Warning: 'OSErrorMsg' is deprecated [Deprecated]
```
