### PR TITLE
Updated inline documentation for clarification

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -52,7 +52,7 @@ type
     path*: string                 ## Path of request.
     cookies*: StringTableRef      ## Cookies from the browser.
     ip*: string                   ## IP address of the requesting client.
-    reqMeth*: ReqMeth             ## Request method: HttpGet or HttpPost
+    reqMeth*: ReqMeth             ## Request method, eg. HttpGet, HttpPost
     settings*: Settings
 
   Response* = ref object

--- a/readme.markdown
+++ b/readme.markdown
@@ -168,7 +168,7 @@ PRequest* = ref object
   path*: string                 ## Path of request.
   cookies*: StringTableRef      ## Cookies from the browser.
   ip*: string                   ## IP address of the requesting client.
-  reqMeth*: TReqMeth            ## Request method: HttpGet or HttpPost 
+  reqMeth*: TReqMeth            ## Request method, eg. HttpGet, HttpPost
   settings*: PSettings
 ```
 


### PR DESCRIPTION
The PR provide a small update to clarify some of the inline documentation.

Previously, the comment for `PRequest.reqMeth` read as `Request method: HttpGet or HttpPost` which may be misunderstood as: request method can only be either `HttpGet` or `HttpPost`, and no other request methods are available.