### PR TITLE
use qualified name for Response

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -786,7 +786,7 @@ macro routes*(body: stmt): stmt {.immediate.} =
   matchBody.add caseStmt
 
   var matchProc = parseStmt("proc match(request: Request," &
-    "response: Response): Future[bool] {.async.} = discard")
+    "response: jester.Response): Future[bool] {.async.} = discard")
   matchProc[0][6] = matchBody
   result.add(outsideStmts)
   result.add(matchProc)


### PR DESCRIPTION
Fix name clash when importing `httpclient`.