### PR TITLE
Check file permissions of static files

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -189,7 +189,12 @@ proc sendStaticIfExists(client: AsyncSocket, req: Request, jes: Jester,
   for p in paths:
     if existsFile(p):
 
-      # TODO: Check file permissions
+      var fp = getFilePermissions(p)
+      if not fp.contains(fpOthersRead):
+        await client.statusContent($Http403, error($Http403, jesterVer),
+                         {"Content-Type": "text/html;charset=utf-8"}.newStringTable)
+        return
+
       var file = readFile(p)
 
       var hashed = getMD5(file)

--- a/readme.markdown
+++ b/readme.markdown
@@ -128,6 +128,9 @@ using the ``setStaticDir`` function. Files will be served like so:
 
 ./public/css/style.css ``->`` http://example.com/css/style.css
 
+**Note**: Jester will only serve files, that are readable by ``others``. On
+Unix/Linux you can ensure this with ``chmod o+r ./public/css/style.css``.
+
 ## Cookies
 
 Cookies can be set using the ``setCookie`` function.


### PR DESCRIPTION
Static files should be readable by “others.” If others are not allowed
to read the requested file, return a HTTP status 403 (“Forbidden”).

Is this okay or did I forget to add tests or an issue?