### PR TITLE
Add a feature about writting separate routes in multiple files

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -276,11 +276,12 @@ proc handleRequest(jes: Jester, client: AsyncSocket,
     try:
       matchProcFut = matchProc(req, resp)
       matched = await matchProcFut
+      if matched:
+        break
     except:
       # Handle any errors by showing them in the browser.
       # TODO: Improve the look of this.
       failed = true
-    if matched:
       break
 
   if failed:
@@ -715,9 +716,6 @@ macro routes*(body: stmt): stmt {.immediate.} =
   #echo(treeRepr(body))
   result = newStmtList()
 
-  # -> declareSettings()
-  result.add newCall(bindSym"declareSettings")
-
   var outsideStmts = newStmtList()
 
   var matchBody = newNimNode(nnkStmtList)
@@ -812,7 +810,7 @@ macro routes*(body: stmt): stmt {.immediate.} =
   blockStmt.add(blockStmtList)
   result.add(outsideStmts)
   result.add(blockStmt)
-
+  echo repr result
   #echo toStrLit(result)
   #echo treeRepr(result)
 

--- a/jester.nim
+++ b/jester.nim
@@ -20,7 +20,7 @@ type
   Jester = object
     httpServer*: AsyncHttpServer
     settings: Settings
-    matchProc: proc (request: Request, response: Response): Future[bool] {.gcsafe.}
+    matchProcs: seq[proc (request: Request, response: Response): Future[bool] {.gcsafe.}]
 
   Settings* = ref object
     staticDir*: string # By default ./public
@@ -81,6 +81,12 @@ type
   TReqMeth: ReqMeth, TCallbackAction: CallbackAction, TCallback: Callback].}
 
 const jesterVer = "0.1.0"
+
+var jes: Jester
+jes.matchProcs = @[]
+
+proc addMatch*(match: proc (request: Request, response: Response): Future[bool] {.gcsafe.}) =
+  jes.matchProcs.add(match)
 
 proc createHeaders(status: string, headers: StringTableRef): string =
   result = ""
@@ -266,13 +272,16 @@ proc handleRequest(jes: Jester, client: AsyncSocket,
 
   var failed = false # Workaround for no 'await' in 'except' body
   var matchProcFut: Future[bool]
-  try:
-    matchProcFut = jes.matchProc(req, resp)
-    matched = await matchProcFut
-  except:
-    # Handle any errors by showing them in the browser.
-    # TODO: Improve the look of this.
-    failed = true
+  for matchProc in jes.matchProcs:
+    try:
+      matchProcFut = matchProc(req, resp)
+      matched = await matchProcFut
+    except:
+      # Handle any errors by showing them in the browser.
+      # TODO: Improve the look of this.
+      failed = true
+    if matched:
+      break
 
   if failed:
     let traceback = getStackTrace(matchProcFut.error).replace("\n", "<br/>\n")
@@ -313,16 +322,11 @@ proc newSettings*(port = Port(5000), staticDir = getCurrentDir() / "public",
                      port: port,
                      bindAddr: bindAddr)
 
-proc serve*(
-    match:
-      proc (request: Request, response: Response): Future[bool] {.gcsafe.},
-    settings: Settings = newSettings()) =
+proc serve*(settings: Settings = newSettings()) {.async.} =
   ## Creates a new async http server or scgi server instance and registers
   ## it with the dispatcher.
-  var jes: Jester
   jes.settings = settings
   jes.settings.mimes = newMimetypes()
-  jes.matchProc = match
   jes.httpServer = newAsyncHttpServer()
 
   # Ensure we have at least one logger enabled, defaulting to console.
@@ -330,15 +334,15 @@ proc serve*(
     addHandler(logging.newConsoleLogger())
     setLogFilter(when defined(release): lvlInfo else: lvlDebug)
 
-  asyncCheck jes.httpServer.serve(jes.settings.port,
-    proc (req: asynchttpserver.Request): Future[void] {.gcsafe.} =
-      handleHTTPRequest(jes, req), settings.bindAddr)
   if settings.bindAddr.len > 0:
     logging.info("Jester is making jokes at http://$1:$2$3" %
                  [settings.bindAddr, $jes.settings.port, jes.settings.appName])
   else:
     logging.info("Jester is making jokes at http://localhost:$1$2" %
                  [$jes.settings.port, jes.settings.appName])
+  await jes.httpServer.serve(jes.settings.port,
+    proc (req: asynchttpserver.Request): Future[void] {.gcsafe.} =
+      handleHTTPRequest(jes, req), settings.bindAddr)
 
 template resp*(code: HttpCode,
                headers: openarray[tuple[key, value: string]],
@@ -799,10 +803,16 @@ macro routes*(body: stmt): stmt {.immediate.} =
   var matchProc = parseStmt("proc match(request: Request," &
     "response: jester.Response): Future[bool] {.async.} = discard")
   matchProc[0][6] = matchBody
+  var addMacthProc = parseStmt("jester.addMatch(match)")
+  var blockStmt = newNimNode(nnkBlockStmt)
+  blockStmt.add(newNimNode(nnkEmpty))
+  var blockStmtList = newNimNode(nnkStmtList)
+  blockStmtList.add(matchProc)
+  blockStmtList.add(addMacthProc)
+  blockStmt.add(blockStmtList)
   result.add(outsideStmts)
-  result.add(matchProc)
+  result.add(blockStmt)
 
-  result.add parseExpr("jester.serve(match, settings)")
   #echo toStrLit(result)
   #echo treeRepr(result)
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -13,7 +13,7 @@ routes:
   get "/":
     resp h1("Hello world")
 
-runForever()
+waitFor jester.serve(settings)
 ```
 
 Compile and run with:
@@ -68,6 +68,35 @@ get "/hello/@name?":
 In this case you might want to make the leading '/' optional too, you can do this
 by changing the pattern to "/hello/?@name?". This is useful because Jester will
 not match "/hello" if the leading '/' is not made optional.
+
+## Separate Routes
+
+You can write separate routes in multiple ``routes`` or multiple files.
+
+helloroute.nim:
+
+```nimrod
+routes:
+  get "/hello":
+    resp "get hello"
+  post "/hello":
+    resp "post hello"
+```
+
+server.nim:
+
+```nimrod
+routes:
+  get "/":
+    resp "get /"
+  post "/":
+    resp "post /"
+
+include "helloroute.nim"
+# include more route files ...
+
+waitFor jester.serve(settings)
+```
 
 ### Regex
 
@@ -189,5 +218,5 @@ routes:
     var push = parseJson(@"payload")
     resp "I got some JSON: " & $push
 
-runForever()
+waitFor jester.serve(settings)
 ```

--- a/readme.markdown
+++ b/readme.markdown
@@ -13,7 +13,7 @@ routes:
   get "/":
     resp h1("Hello world")
 
-waitFor jester.serve(settings)
+waitFor jester.serve()
 ```
 
 Compile and run with:
@@ -86,6 +86,9 @@ routes:
 server.nim:
 
 ```nimrod
+settings:
+  bindAddr = "0.0.0.0"
+
 routes:
   get "/":
     resp "get /"
@@ -218,5 +221,5 @@ routes:
     var push = parseJson(@"payload")
     resp "I got some JSON: " & $push
 
-waitFor jester.serve(settings)
+waitFor jester.serve()
 ```


### PR DESCRIPTION
Now, we can write separate routes in multiple ``routes`` or multiple files. 

For example, this is the directory structure of our project:

```
app
|- routes1.nim
|- routes2.nim
|- server.nim
```

routes1.nim:

```nim
routes:
  get "/route1":
    resp "get /route1"
  post "/route1":
    resp "post /route1"
```

routes2.nim:

```nim
routes:
  get "/route2":
    resp "get /route2"
  post "/route2":
    resp "post /route2"
```

server.nim:

```nim
import jester, asyncdispath

include "routes1.nim"
include "routes2.nim"

waitFor jester.serve(settings)
```