### PR TITLE
Fixing templates and macros for Jester

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -361,6 +361,7 @@ template resp*(code: HttpCode,
   ## Sets ``(code, headers, content)`` as the response.
   bind TCActionSend, newStringTable
   response.data = (TCActionSend, code, headers.newStringTable, content)
+  break route
   # The ``route`` macro will add a 'return' after the invokation of this
   # template.
 
@@ -372,6 +373,7 @@ template resp*(content: string, contentType = "text/html;charset=utf-8"): stmt =
   response.data[1] = Http200
   response.data[2]["Content-Type"] = contentType
   response.data[3] = content
+  break route
   # The ``route`` macro will add a 'return' after the invokation of this
   # template.
 
@@ -384,6 +386,7 @@ template resp*(code: HttpCode, content: string,
   response.data[1] = code
   response.data[2]["Content-Type"] = contentType
   response.data[3] = content
+  break route
   # The ``route`` macro will add a 'return' after the invokation of this
   # template.
 
@@ -416,6 +419,7 @@ template redirect*(url: string): stmt =
   response.data[1] = Http303
   response.data[2]["Location"] = url
   response.data[3] = ""
+  break route
   # The ``route`` macro will add a 'return' after the invokation of this
   # template.
 
@@ -424,12 +428,14 @@ template pass*(): stmt =
   ##
   ## If you want to stop this request from going further use ``halt``.
   response.data.action = TCActionPass
+  break outerRoute
   # The ``route`` macro will perform a transformation which ensures a
   # call to this template behaves correctly.
 
 template cond*(condition: bool): stmt =
   ## If ``condition`` is ``False`` then ``pass`` will be called,
   ## i.e. this request handler will be skipped.
+  if not condition: break outerRoute
   # The ``route`` macro will perform a transformation which ensures a
   # call to this template behaves correctly.
 
@@ -441,6 +447,7 @@ template halt*(code: HttpCode,
   ## route.
   bind TCActionSend, newStringTable
   response.data = (TCActionSend, code, headers.newStringTable, content)
+  break route
   # The ``route`` macro will add a 'return' after the invokation of this
   # template.
 
@@ -622,31 +629,6 @@ template declareSettings(): stmt {.immediate, dirty.} =
   when not declaredInScope(settings):
     var settings = newSettings()
 
-proc transformRouteBody(node, thisRouteSym: NimNode): NimNode {.compiletime.} =
-  result = node
-  case node.kind
-  of nnkCall, nnkCommand:
-    if node[0].kind == nnkIdent:
-      case node[0].ident.`$`.normalize
-      of "pass":
-        result = newStmtList()
-        result.add node
-        result.add newNimNode(nnkBreakStmt).add(thisRouteSym)
-      of "redirect", "halt", "resp":
-        result = newStmtList()
-        result.add node
-        result.add newNimNode(nnkReturnStmt).add(newIdentNode("true"))
-      of "cond":
-        var cond = newNimNode(nnkPrefix).add(newIdentNode("not"), node[1])
-        var condBody = newStmtList().add(getAst(pass()),
-            newNimNode(nnkBreakStmt).add(thisRouteSym))
-
-        result = newIfStmt((cond, condBody))
-      else: discard
-  else:
-    for i in 0 .. <node.len:
-      result[i] = transformRouteBody(node[i], thisRouteSym)
-
 proc createJesterPattern(body,
      patternMatchSym: NimNode, i: int): NimNode {.compileTime.} =
   var ctPattern = ctParsePattern(body[i][1].strVal)
@@ -678,7 +660,6 @@ proc createRoute(body, dest: NimNode, i: int) {.compileTime.} =
   ## Creates code which checks whether the current request path
   ## matches a route.
 
-  var thisRouteSym = genSym(nskLabel, "thisRoute")
   var patternMatchSym = genSym(nskLet, "patternMatchRet")
 
   # Only used for Regex patterns.
@@ -707,10 +688,16 @@ proc createRoute(body, dest: NimNode, i: int) {.compileTime.} =
         newDotExpr(newIdentNode"request", newIdentNode"matches"),
         reMatchesSym)
 
-  ifStmtBody.add body[i][2].skipDo().transformRouteBody(thisRouteSym)
+  ifStmtBody.add body[i][2].skipDo()
   var checkActionIf = parseExpr("if checkAction(response): return true")
   checkActionIf[0][0][0] = bindSym"checkAction"
-  ifStmtBody.add checkActionIf
+  #ifStmtBody.add checkActionIf
+  
+  # -> block route: <ifStmtBody>; <checkActionIf>
+  var innerBlockStmt = newStmtList(
+    newNimNode(nnkBlockStmt).add(newIdentNode(!"route"), ifStmtBody),
+    checkActionIf
+  )
 
   let ifCond =
     case patternType
@@ -719,12 +706,12 @@ proc createRoute(body, dest: NimNode, i: int) {.compileTime.} =
     of MRegex:
       infix(patternMatchSym, "!=", newIntLitNode(-1))
 
-  # -> if <patternMatchSym>.matched: <ifStmtBody>
-  var ifStmt = newIfStmt((ifCond, ifStmtBody))
+  # -> if <patternMatchSym>.matched: <innerBlockStmt>
+  var ifStmt = newIfStmt((ifCond, innerBlockStmt))
 
   # -> block <thisRouteSym>: <ifStmt>
   var blockStmt = newNimNode(nnkBlockStmt).add(
-    thisRouteSym, ifStmt)
+    newIdentNode(!"outerRoute"), ifStmt)
   dest.add blockStmt
 
 macro routes*(body: stmt): stmt {.immediate.} =

--- a/jester.nim
+++ b/jester.nim
@@ -362,8 +362,6 @@ template resp*(code: HttpCode,
   bind TCActionSend, newStringTable
   response.data = (TCActionSend, code, headers.newStringTable, content)
   break route
-  # The ``route`` macro will add a 'return' after the invokation of this
-  # template.
 
 template resp*(content: string, contentType = "text/html;charset=utf-8"): stmt =
   ## Sets ``content`` as the response; ``Http200`` as the status code
@@ -374,8 +372,6 @@ template resp*(content: string, contentType = "text/html;charset=utf-8"): stmt =
   response.data[2]["Content-Type"] = contentType
   response.data[3] = content
   break route
-  # The ``route`` macro will add a 'return' after the invokation of this
-  # template.
 
 template resp*(code: HttpCode, content: string,
                contentType = "text/html;charset=utf-8"): stmt =
@@ -387,8 +383,6 @@ template resp*(code: HttpCode, content: string,
   response.data[2]["Content-Type"] = contentType
   response.data[3] = content
   break route
-  # The ``route`` macro will add a 'return' after the invokation of this
-  # template.
 
 template body*(): expr =
   ## Gets the body of the request.
@@ -420,8 +414,6 @@ template redirect*(url: string): stmt =
   response.data[2]["Location"] = url
   response.data[3] = ""
   break route
-  # The ``route`` macro will add a 'return' after the invokation of this
-  # template.
 
 template pass*(): stmt =
   ## Skips this request handler.
@@ -429,15 +421,11 @@ template pass*(): stmt =
   ## If you want to stop this request from going further use ``halt``.
   response.data.action = TCActionPass
   break outerRoute
-  # The ``route`` macro will perform a transformation which ensures a
-  # call to this template behaves correctly.
 
 template cond*(condition: bool): stmt =
   ## If ``condition`` is ``False`` then ``pass`` will be called,
   ## i.e. this request handler will be skipped.
   if not condition: break outerRoute
-  # The ``route`` macro will perform a transformation which ensures a
-  # call to this template behaves correctly.
 
 template halt*(code: HttpCode,
                headers: varargs[tuple[key, val: string]],
@@ -448,8 +436,6 @@ template halt*(code: HttpCode,
   bind TCActionSend, newStringTable
   response.data = (TCActionSend, code, headers.newStringTable, content)
   break route
-  # The ``route`` macro will add a 'return' after the invokation of this
-  # template.
 
 template halt*(): stmt =
   ## Halts the execution of this request immediately. Returns a 404.

--- a/tests/alltest.nim
+++ b/tests/alltest.nim
@@ -2,6 +2,9 @@
 # MIT License - Look at license.txt for details.
 import jester, asyncdispatch, strutils, random, os, asyncnet, re
 
+template return200(): untyped =
+  resp Http200, "Templates now work!"
+
 settings:
   port = Port(5454)
   appName = "/foo"
@@ -100,5 +103,9 @@ routes:
     body.add "Received: "
     body.add($request.body)
     status = Http200
+
+  get "/template":
+    return200()
+    resp Http404, "Template not working"
 
 runForever()

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -34,3 +34,7 @@ test "regex":
 test "resp":
   let resp = waitFor client.get("http://localhost:" & $port & "/foo/resp")
   check (waitFor resp.body) == "This should be the response"
+
+test "template":
+  let resp = waitFor client.get("http://localhost:" & $port & "/foo/template")
+  check (waitFor resp.body) == "Templates now work!"


### PR DESCRIPTION
This replaces the method of adding return statements to the AST to break out of routes with a block and a break statement which works for templates and macros as well.