### PR TITLE
Added support for having multiple matchers

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -355,6 +355,19 @@ proc serve*(
     logging.info("Jester is making jokes at http://localhost:$1$2" %
                  [$jes.settings.port, jes.settings.appName])
 
+template serveAll*(
+    matchers: untyped,
+    settings: Settings = newSettings()): untyped =
+  serve((
+    proc (request: Request, response: Response): Future[bool] {.async.} =
+      var allMatchers = matchers
+      result = false
+      for matcher in allMatchers:
+        result = await matcher(request, response)
+        if result: break
+    )
+    , settings)
+
 template resp*(code: HttpCode,
                headers: openarray[tuple[key, value: string]],
                content: string): stmt =
@@ -727,15 +740,7 @@ proc createRoute(body, dest: NimNode, i: int) {.compileTime.} =
     thisRouteSym, ifStmt)
   dest.add blockStmt
 
-macro routes*(body: stmt): stmt {.immediate.} =
-  #echo(treeRepr(body))
-  result = newStmtList()
-
-  # -> declareSettings()
-  result.add newCall(bindSym"declareSettings")
-
-  var outsideStmts = newStmtList()
-
+macro matcher*(name: untyped, body: stmt): untyped {.immediate.} =
   var matchBody = newNimNode(nnkStmtList)
   matchBody.add newCall(bindSym"setDefaultResp")
   var caseStmt = newNimNode(nnkCaseStmt)
@@ -781,10 +786,8 @@ macro routes*(body: stmt): stmt {.immediate.} =
           discard
       else:
         discard
-    of nnkCommentStmt:
-      discard
     else:
-      outsideStmts.add(body[i])
+      discard
 
   var ofBranchGet = newNimNode(nnkOfBranch)
   ofBranchGet.add newIdentNode("HttpGet")
@@ -833,11 +836,26 @@ macro routes*(body: stmt): stmt {.immediate.} =
 
   matchBody.add caseStmt
 
-  var matchProc = parseStmt("proc match(request: Request," &
-    "response: jester.Response): Future[bool] {.async, gcsafe.} = discard")
-  matchProc[0][6] = matchBody
-  result.add(outsideStmts)
-  result.add(matchProc)
+  let
+    request = newIdentNode(!"request")
+    response = newIdentNode(!"response")
+
+  result = quote do:
+    proc `name`(`request`: Request, `response`: jester.Response): Future[bool] {.async, gcsafe.} =
+      `matchBody`
+  #echo result.toStrLit
+
+macro routes*(body: stmt): stmt {.immediate.} =
+  #echo(treeRepr(body))
+  result = newStmtList()
+
+  # -> declareSettings()
+  result.add newCall(bindSym"declareSettings")
+
+  #var outsideStmts = newStmtList()
+
+  #result.add(outsideStmts)
+  result.add(getAst(matcher(newIdentNode(!"match"), body)))
 
   result.add parseExpr("jester.serve(match, settings)")
   #echo toStrLit(result)

--- a/tests/example3.nim
+++ b/tests/example3.nim
@@ -1,0 +1,28 @@
+import jester, asyncdispatch, asyncnet, htmlgen
+
+matcher(matcher1):
+  get "/":
+    resp h1("Hello world")
+  get "/err":
+    resp Http404, "This is an error"
+
+matcher(matcher2):
+  get "/second":
+    resp h1("Hello from second matcher")
+
+# Example of combining two matchers into one
+var alternate = 0
+proc myMatcher(request: Request, response: Response): Future[bool] {.async.} =
+  if alternate == 0:
+    result = await matcher1(request, response)
+    alternate = 1
+  else:
+    result = await matcher2(request, response)
+    alternate = 0
+
+jester.serve(myMatcher)
+
+# We now also have a serveAll that just goes through the matchers until one fits
+#jester.serveAll(@[matcher1, matcher2])
+
+runForever()


### PR DESCRIPTION
Most of the `routes` macro is now split out into a new macro `matcher` that creates a matcher without starting to listen for connections. This allows splitting the routes block into multiple parts and also select which matcher to use which could be a powerful tool to allow more complex routing. See the new file `tests/example3.nim` for an example on how to use this.

NOTE: outsideStmts is now not possible, any code in the `routes` macro that doesn't belong in a route is simply ignored (maybe this should raise an error instead?)