### PR TITLE
Replaced expr/stmt by untyped/typed and removed immediate pragma.

### DIFF
--- a/jester/private/patterns.nim
+++ b/jester/private/patterns.nim
@@ -15,7 +15,7 @@ type
 proc parsePattern*(pattern: string): Pattern =
   result = @[]
   template addNode(result: var Pattern, theT: NodeType, theText: string,
-                   isOptional: bool): stmt =
+                   isOptional: bool): typed =
     block:
       var newNode: Node
       newNode.typ = theT

--- a/jester/private/utils.nim
+++ b/jester/private/utils.nim
@@ -21,7 +21,7 @@ proc parseUrlQuery*(query: string, result: var StringTableRef) =
     inc(i) # Skip &
     result[decodeUrl(key)] = decodeUrl(val)
 
-template parseContentDisposition(): stmt =
+template parseContentDisposition(): typed =
   var hCount = 0
   while hCount < hValue.len()-1:
     var key = ""


### PR DESCRIPTION
Hello Dominik. I am very pleased by jester and how simple the DSL it exposes is. I have straight-away started making internal use of it here at the lab to expose all sorts of neat things on the intranet. I am using jester with nim 0.17.2. From what I understand, stmt and expr may be replaced safely by typed and untyped. In addition, the immediate pragma appears to be going the way of history, and apparently it is just fine to use an untyped parameter to achieve the same effect. I've done a quick replacement of stmt/expr with typed/untyped, and removed immediate.

Please let me know if you would be okay with merging this. Thanks!