### PR TITLE
gitignore binaries generated by nimble test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+/tests/*
+!/tests/*.nim
+!/tests/*/
+
 nimcache


### PR DESCRIPTION
this gitignores all the non nim files under tests/ (but not deeper). Seems correct.
