### PR TITLE
Fix cookie datetime conversion and missing parameters [bugfix]

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -726,7 +726,7 @@ template setCookie*(name, value: string, expires: DateTime,
   ## Creates a cookie which stores ``value`` under ``name``.
   setCookie(name, value,
             format(expires.utc, "ddd',' dd MMM yyyy HH:mm:ss 'GMT'"),
-            sameSite, secure, httpOnly)
+            sameSite, secure, httpOnly, domain, path)
 
 proc normalizeUri*(uri: string): string =
   ## Remove any trailing ``/``.

--- a/jester.nim
+++ b/jester.nim
@@ -724,7 +724,8 @@ template setCookie*(name, value: string, expires: DateTime,
                     sameSite: SameSite=Lax, secure = false,
                     httpOnly = false, domain = "", path = ""): typed =
   ## Creates a cookie which stores ``value`` under ``name``.
-  setCookie(name, value, format(expires, "ddd',' dd MMM yyyy HH:mm:ss 'GMT'"),
+  setCookie(name, value,
+            format(expires.utc, "ddd',' dd MMM yyyy HH:mm:ss 'GMT'"),
             sameSite, secure, httpOnly)
 
 proc normalizeUri*(uri: string): string =


### PR DESCRIPTION
DateTime was not converted to UTC before being marked as GMT in the cookie.  Also was missing a couple of cookie parameters such as domain and path -- which are necessary to make the cookie work.
