### PR TITLE
[WIP] Create new router macro for use in closure routes

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -1374,8 +1374,9 @@ proc routesEx(name: string, body: NimNode, isClosure = false): NimNode =
   result.add(errorHandlerProc)
 
   # If this is a closure, return the tuple of procs
-  result.add quote do:
-    return (router: `matchIdent`, handler: `errorHandlerIdent`)
+  if isClosure:
+    result.add quote do:
+      return (router: `matchIdent`, handler: `errorHandlerIdent`)
 
   # TODO: Replace `body`, `headers`, `code` in routes with `result[i]` to
   # get these shortcuts back without sacrificing usability.


### PR DESCRIPTION
This is a WIP PR to take care of #229

I created a new router specifically for use in closures. It adds the `{.closure.}` pragma to both the `matchIdent` and `errorHandlerIdent` procs, as well as returning them in a tuple. This tuple is of type:
```nim
tuple[
  router: proc (request: Request): ResponseData{.closure, noSideEffect, gcsafe, locks: 0.},
  handler: proc (request: Request; error: RouteError): Future[ResponseData] {.closure, gcsafe.}
]
```
For convenience, this tuple is declared as a new type: `RouterTuple`.

This PR is a WIP pending input from dom96. The router works (as far as I've checked), but I'm not at all happy with the new code. There's code duplication everywhere, and I feel the new `if..else` branches checking for `isClosure` are needlessly complicated. I have a few ideas for different directions this could take, but I'm not sure what dom96 is willing to work with and maintain.
In addition, it also needs documentation and tests.