### PR TITLE
rename header value as val

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -526,7 +526,7 @@ template setHeader(headers: var Option[RawHeaders], key, value: string): typed =
       headers = some(h & @({key: value}))
 
 template resp*(code: HttpCode,
-               headers: openarray[tuple[key, value: string]],
+               headers: openarray[tuple[key, val: string]],
                content: string): typed =
   ## Sets ``(code, headers, content)`` as the response.
   bind TCActionSend


### PR DESCRIPTION
header tuple should be `tuple[key, val: string]` because difinition of header in `newHttpHeaders` is `tuple[key, val: string]`  

[proc newHttpHeaders](https://nim-lang.org/docs/httpcore.html#newHttpHeaders%2CopenArray%5Btuple%5Bstring%2Cstring%5D%5D)

Especially, when using `after`, error is happened
```nim
routes:
  after re"/api.*":
    var headers = result[2].get # tuple[key, val: string]
    headers.add(("key", "val"))
    resp result[1], headers, result[3] # error railed becase expected header is tuple[key, value: string]
```