### PR TITLE
Use async to fix asynchttpserver

### DIFF
--- a/jester/request.nim
+++ b/jester/request.nim
@@ -61,6 +61,7 @@ proc reqMethod*(req: Request): HttpMethod =
     req.req.httpMethod.get()
   else:
     req.req.reqMethod
+
 proc reqMeth*(req: Request): HttpMethod {.deprecated.} =
   req.reqMethod
 


### PR DESCRIPTION
This fixes the "Bad file descriptor" error when running asynchttpserver behind an nginx instance. There might be some more serious underlying issue causing this, but for now I see it as Jester using asynchttpserver incorrectly which is fixed in this pr. Tested with both asynchttpserver and httpbeast.