### PR TITLE
fixed paths for staticDir on windows which returned 400 bad request.

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -307,8 +307,9 @@ proc handleFileRequest(
 ): Future[ResponseData] {.async.} =
   # Find static file.
   # TODO: Caching.
-  let path = normalizedPath(
-    jes.settings.staticDir / cgi.decodeUrl(req.pathInfo)
+  # no need to normalize staticDir since it is normalized in `newSettings`
+  let path = jes.settings.staticDir / normalizedPath(
+    cgi.decodeUrl(req.pathInfo)
   )
 
   # Verify that this isn't outside our static dir.
@@ -409,7 +410,7 @@ proc newSettings*(
   futureErrorHandler: proc (fut: Future[void]) {.closure, gcsafe.} = nil
 ): Settings =
   result = Settings(
-    staticDir: staticDir,
+    staticDir: normalizedPath(staticDir),
     appName: appName,
     port: port,
     bindAddr: bindAddr,


### PR DESCRIPTION
I was running jester on windows and couldn't get static files to be served without incurring a 400 bad request. After digging around the source I found that the comparison on line 318 of the original source `if pathDir.startsWith(staticDir)` would return false because of a trailing slash.
Example:

`pathDir = "%somepath%/client/build"`
`staticDir = "%somepath%/client/build/"`

 After changing the way the pathDir prevents directory traversal and ensuring that the staticDir is always without a trailing slash, it works on windows.

I wanted to test using `nimble test` but unfortunately they are unable to run due to a combination of out of date async libraries `PCustomOverlap -> CustomRef` and the inability to run the asyncdispatcher server which I didn't look into.

I was hoping you could review and comment on any concerns with the changes.
