### PR TITLE
Make tests pass

### DIFF
--- a/tests/issue150.nim
+++ b/tests/issue150.nim
@@ -4,6 +4,7 @@ import jester
 
 settings:
   port = Port(5454)
+  bindAddr = "127.0.0.1"
 
 routes:
   get "/":

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -11,12 +11,20 @@ const
 var serverProcess: AsyncProcess
 
 proc readLoop(process: AsyncProcess) {.async.} =
-  while process.running:
+  var wholebuf: string
+  while true:
     var buf = newString(256)
     let len = await readInto(process.outputHandle, addr buf[0], 256)
+    if len == 0:
+      break
     buf.setLen(len)
-    styledEcho(fgBlue, "Process: ", resetStyle, buf.strip())
-
+    wholebuf.add(buf)
+    while "\l" in wholebuf:
+      let parts = wholebuf.split("\l", 1)
+      styledEcho(fgBlue, "Process: ", resetStyle, parts[0])
+      wholebuf = parts[1]
+  if wholebuf != "":
+    styledEcho(fgBlue, "Process: ", resetStyle, wholebuf)
   styledEcho(fgRed, "Process terminated")
 
 proc startServer(file: string, useStdLib: bool) {.async.} =


### PR DESCRIPTION
Finding this fix took forever and I don't understand it.  Without this change, running `nimble test` would produce the following SIGSEGV in the `alltest.nim` process:

```
Process: INFO Jester is making jokes at http://127.0.0.1:5454/foo
Process: Starting 1 threads
Getting http://localhost:5454 - attempt 0
Process: ERROR /Users/matt/lib/jester/tests/alltest.nim(29) alltest
Process: /Users/matt/lib/jester/jester.nim(494) serve
Process: /Users/matt/.nimble/pkgs/httpbeast-0.2.2/httpbeast.nim(426) run
Process: /Users/matt/.nimble/pkgs/httpbeast-0.2.2/httpbeast.nim(288) eventLoop
Process: /Users/matt/.nimble/pkgs/httpbeast-0.2.2/httpbeast.nim(219) processEvents
Process: /Users/matt/lib/jester/jester.nim(497) :anonymous
Process: /Users/matt/lib/jester/jester.nim(385) handleRequest
Process: /Users/matt/lib/jester/jester/request.nim(159) pathInfo
Process: /Users/matt/lib/jester/jester/request.nim(153) stripAppName
Process: Expected script name at beginning of path. Got path: / script name: /foo
Process: Traceback (most recent call last)
Process: /Users/matt/lib/jester/tests/alltest.nim(29) alltest
Process: /Users/matt/lib/jester/jester.nim(494) serve
Process: /Users/matt/.nimble/pkgs/httpbeast-0.2.2/httpbeast.nim(426) run
Process: /Users/matt/.nimble/pkgs/httpbeast-0.2.2/httpbeast.nim(288) eventLoop
Process: /Users/matt/.nimble/pkgs/httpbeast-0.2.2/httpbeast.nim(219) processEvents
Process: /Users/matt/lib/jester/jester.nim(497) :anonymous
Process: /Users/matt/lib/jester/jester.nim(403) handleRequest
Process: SIGSEGV: Illegal storage access. (Attempt to read from nil?)
Process: DEBUG   502 Bad Gateway {"content-type": @["text/html;charset=utf-8"]}
```

By rewriting the `try: await ... except: ...` to use `yields` it no longer has a segfault.  I suspect there's a Nim bug hidden in here somewhere, but I don't understand it enough to know how to file a useful report.

I also included some quality of life changes to the testing to:

1. Abort tests early if the server is dead (instead of trying 10 times for 3 seconds each time)
2. Display the full subprocess output instead of sometimes truncating it.
3. Not ask me firewall permission when running `issue150.nim`

Feel free to cherry-pick or exclude those commits if you don't want them.