### PR TITLE
Use GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: tests
+on:
+  push:
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 0 * * 1'
+
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        nimversion:
+        - stable
+        - devel
+        os:
+        - ubuntu-latest
+        - macOS-latest
+        - windows-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: iffy/install-nim@v1.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        nimversion: ${{ matrix.nimversion }}
+    - name: Test
+      run: |
+        nimble test
+        nimble refresh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
         - windows-latest
     steps:
     - uses: actions/checkout@v1
+      with:
+        submodules: true
     - uses: iffy/install-nim@v1.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/nim-in-action-code"]
+	path = tests/nim-in-action-code
+	url = https://github.com/dom96/nim-in-action-code.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tests/nim-in-action-code"]
-	path = tests/nim-in-action-code
-	url = https://github.com/dom96/nim-in-action-code.git

--- a/jester.nimble
+++ b/jester.nimble
@@ -13,10 +13,15 @@ skipDirs = @["tests"]
 requires "nim >= 0.18.1"
 
 when not defined(windows):
-  requires "httpbeast >= 0.2.2"
+  # When https://github.com/cheatfate/asynctools/pull/28 is fixed,
+  # change this back to normal httpbeast
+  # requires "httpbeast >= 0.2.2"
+  requires "https://github.com/iffy/httpbeast#github-actions"
 
 # For tests
-requires "https://github.com/alehander92/asynctools"
+# When https://github.com/cheatfate/asynctools/pull/28 is fixed,
+# change this back to normal asynctools
+requires "https://github.com/iffy/asynctools#pr_fix_for_latest"
 
 task test, "Runs the test suite.":
   exec "nimble c -y -r tests/tester"

--- a/jester.nimble
+++ b/jester.nimble
@@ -16,7 +16,7 @@ when not defined(windows):
   requires "httpbeast >= 0.2.2"
 
 # For tests
-requires "https://github.com/timotheecour/asynctools#pr_fix_compilation"
+requires "https://github.com/alehander92/asynctools"
 
 task test, "Runs the test suite.":
   exec "nimble c -y -r tests/tester"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -240,11 +240,7 @@ when isMainModule:
 
     # Verify that Nim in Action Tweeter still compiles.
     test "Nim in Action - Tweeter":
-      let niminaction_path = "tests/nim-in-action-code"
-      if not niminaction_path.existsDir:
-        checkpoint "Fetching Nim in Action code..."
-        check execCmd("git clone https://github.com/dom96/nim-in-action-code.git " & niminaction_path) == QuitSuccess
-      let tweeter_path = niminaction_path / "Chapter7" / "Tweeter" / "src" / "tweeter.nim"
-      check execCmd("nim c --path:. " & tweeter_path) == QuitSuccess
+      let path = "tests/nim-in-action-code/Chapter7/Tweeter/src/tweeter.nim"
+      check execCmd("nim c --path:. " & path) == QuitSuccess
   finally:
     doAssert execCmd("kill -15 " & $serverProcess.processID()) == QuitSuccess

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -240,7 +240,11 @@ when isMainModule:
 
     # Verify that Nim in Action Tweeter still compiles.
     test "Nim in Action - Tweeter":
-      let path = "tests/nim-in-action-code/Chapter7/Tweeter/src/tweeter.nim"
-      check execCmd("nim c --path:. " & path) == QuitSuccess
+      let niminaction_path = "tests/nim-in-action-code"
+      if not niminaction_path.existsDir:
+        checkpoint "Fetching Nim in Action code..."
+        check execCmd("git clone https://github.com/dom96/nim-in-action-code.git " & niminaction_path) == QuitSuccess
+      let tweeter_path = niminaction_path / "Chapter7" / "Tweeter" / "src" / "tweeter.nim"
+      check execCmd("nim c --path:. " & tweeter_path) == QuitSuccess
   finally:
     doAssert execCmd("kill -15 " & $serverProcess.processID()) == QuitSuccess


### PR DESCRIPTION
To get the Jester GitHub CI tests to pass, the following packages need changes:

- choosenim
- asynctools
- httpbeast
- jester

## choosenim

- [x] Release a new version of choosenim, to include the already-merged change to prevent throttling in GitHub Actions: https://github.com/dom96/choosenim/commit/98bcfce076c5a2e3e68653b5ddfe40f4410914fc

None of the macOS tests will pass without this (unless you get really lucky when no one else is using macOS machines).

## asynctools

- [ ] There are 2 fixes that need to be merged into master, and a new version released.  I've combined both fixes into one branch so that httpbeast and jester can use the combined fix.  https://github.com/cheatfate/asynctools/pull/28
- [ ] Release a new version

## httpbeast

- [x] Enable GitHub Actions: https://github.com/dom96/httpbeast/pull/40
- [x] After asynctools is fixed, then httpbeast can be made to depend on the newly-released version
- [ ] Release a new version

## jester

- [ ] Enable GitHub Actions with this PR.
- [ ] Once httpbeast is fixed and a new version is released, depend on that version.
- [ ] Once asynctools is fixed and a new version is released, depend on that version.
