### PR TITLE
Add halt option to redirect; default to halting

### DIFF
--- a/changelog.markdown
+++ b/changelog.markdown
@@ -1,5 +1,9 @@
 # Jester changelog
 
+## x.x.x - xx/xx/xxxx
+
+- **Breaking change:** By default `redirect` now skips future handlers, including when used in a `before` route.  To retain the old behavior, set the parameter `halt=false` (e.g. `redirect("/somewhere", halt=false)`)
+
 ## 0.4.3 - 12/08/2019
 
 Minor release correcting a few packaging issues and includes some other

--- a/jester.nim
+++ b/jester.nim
@@ -578,7 +578,9 @@ template resp*(code: HttpCode): typed =
 
 template redirect*(url: string, halt = true): typed =
   ## Redirects to ``url``. Returns from this request handler immediately.
+  ##
   ## If ``halt`` is true, skips executing future handlers, too.
+  ##
   ## Any set response headers are preserved for this request.
   bind TCActionSend, newHttpHeaders
   result[0] = TCActionSend

--- a/jester.nim
+++ b/jester.nim
@@ -576,8 +576,9 @@ template resp*(code: HttpCode): typed =
   result.matched = true
   break route
 
-template redirect*(url: string): typed =
+template redirect*(url: string, halt = true): typed =
   ## Redirects to ``url``. Returns from this request handler immediately.
+  ## If ``halt`` is true, skips executing future handlers, too.
   ## Any set response headers are preserved for this request.
   bind TCActionSend, newHttpHeaders
   result[0] = TCActionSend
@@ -585,7 +586,10 @@ template redirect*(url: string): typed =
   setHeader(result[2], "Location", url)
   result[3] = ""
   result.matched = true
-  break route
+  if halt:
+    break allRoutes
+  else:
+    break route
 
 template pass*(): typed =
   ## Skips this request handler.

--- a/tests/alltest.nim
+++ b/tests/alltest.nim
@@ -45,6 +45,12 @@ routes:
 
   get "/halt":
     resp "<h1>Not halted!</h1>"
+  
+  before re"/halt-before/.*?":
+    halt Http502, "Halted!"
+  
+  get "/halt-before/@something":
+    resp "Should never reach this"
 
   get "/guess/@who":
     if @"who" != "Frank": pass()
@@ -55,6 +61,16 @@ routes:
 
   get "/redirect/@url/?":
     redirect(uri(@"url"))
+  
+  get "/redirect-halt/@url/?":
+    redirect(uri(@"url"))
+    resp "ok"
+  
+  before re"/redirect-before/.*?":
+    redirect(uri("/nowhere"))
+  
+  get "/redirect-before/@url/?":
+    resp "should not get here"
 
   get "/win":
     cond rand(5) < 3

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -82,6 +82,11 @@ proc allTest(useStdLib: bool) =
     let resp = waitFor client.get(address & "/foo/halt")
     check resp.status.startsWith("502")
     check (waitFor resp.body) == "I'm sorry, this page has been halted."
+  
+  test "/halt-before":
+    let resp = waitFor client.request(address & "/foo/halt-before/something", HttpGet)
+    let body = waitFor resp.body
+    check body == "Halted!"
 
   test "/guess":
     let resp = waitFor client.get(address & "/foo/guess/foo")
@@ -92,6 +97,17 @@ proc allTest(useStdLib: bool) =
   test "/redirect":
     let resp = waitFor client.request(address & "/foo/redirect/halt", HttpGet)
     check resp.headers["location"] == "http://localhost:5454/foo/halt"
+  
+  test "/redirect-halt":
+    let resp = waitFor client.request(address & "/foo/redirect-halt/halt", HttpGet)
+    check resp.headers["location"] == "http://localhost:5454/foo/halt"
+    check (waitFor resp.body) == ""
+  
+  test "/redirect-before":
+    let resp = waitFor client.request(address & "/foo/redirect-before/anywhere", HttpGet)
+    check resp.headers["location"] == "http://localhost:5454/foo/nowhere"
+    let body = waitFor resp.body
+    check body == ""
 
   test "regex":
     let resp = waitFor client.get(address & "/foo/02.html")


### PR DESCRIPTION
Fixes #264

It makes more sense (to me) for halting to be the default behavior when redirecting.  But if you'd rather halt default to false to be completely backward compatible, I can change it.

Sorry for the slew of issues and PRs ;) I'm not expecting you to rush through them