### PR TITLE
Custom routers now get the same default error handling as normal routers

### DIFF
--- a/changelog.markdown
+++ b/changelog.markdown
@@ -4,6 +4,8 @@
 
 - **Breaking change:** By default `redirect` now skips future handlers, including when used in a `before` route.  To retain the old behavior, set the parameter `halt=false` (e.g. `redirect("/somewhere", halt=false)`)
 
+- Fix for [#211](https://github.com/dom96/jester/issues/211) - custom routers now have the same error handling as normal routes.
+
 ## 0.4.3 - 12/08/2019
 
 Minor release correcting a few packaging issues and includes some other

--- a/tests/customRouter.nim
+++ b/tests/customRouter.nim
@@ -1,0 +1,20 @@
+import jester
+
+router myrouter:
+  get "/":
+    resp "Hello world"
+
+  get "/raise":
+    raise newException(Exception, "Foobar")
+
+  error Exception:
+    resp Http500, "Something bad happened: " & exception.msg
+
+when isMainModule:
+  let s = newSettings(
+    Port(5454),
+    bindAddr="127.0.0.1",
+  )
+  var jest = initJester(myrouter, s)
+  # jest.register(myrouterErrorHandler)
+  jest.serve()


### PR DESCRIPTION
Fixes #211

I don't know if this is the way you'd fix it or not.  It pairs the normal matcher and error handler into a tuple which is then passed to `initJester`. If it's needed for backward compatibility, I could add the original `initJester` procs back in.