### PR TITLE
Fix error handler redirecting

### DIFF
--- a/changelog.markdown
+++ b/changelog.markdown
@@ -3,6 +3,7 @@
 ## 0.6.0 - ??/07/2021
 
 - **Breaking change:** the `@` operator used for retrieving request parameters now automatically decodes special characters using `decodeUrl`.
+- Fix for [#211](https://github.com/dom96/jester/issues/211) - custom routers now have the same error handling as normal routes.
 
 ## 0.5.0 - 17/10/2020
 

--- a/changelog.markdown
+++ b/changelog.markdown
@@ -4,6 +4,7 @@
 
 - **Breaking change:** the `@` operator used for retrieving request parameters now automatically decodes special characters using `decodeUrl`.
 - Fix for [#211](https://github.com/dom96/jester/issues/211) - custom routers now have the same error handling as normal routes.
+- Fix for [#269](https://github.com/dom96/jester/issues/269) - a bug that prevented redirecting from within error handlers.
 
 ## 0.5.0 - 17/10/2020
 

--- a/jester.nim
+++ b/jester.nim
@@ -42,6 +42,14 @@ type
     request: Request, error: RouteError
   ): Future[ResponseData] {.gcsafe, closure.}
 
+  MatchPair* = tuple
+    matcher: MatchProc
+    errorHandler: ErrorProc
+
+  MatchPairSync* = tuple
+    matcher: MatchProcSync
+    errorHandler: ErrorProc
+
   Jester* = object
     when not useHttpBeast:
       httpServer*: AsyncHttpServer
@@ -454,18 +462,20 @@ proc initJester*(
   result.errorHandlers = @[]
 
 proc initJester*(
-  matcher: MatchProc,
+  pair: MatchPair,
   settings: Settings = newSettings()
 ): Jester =
   result = initJester(settings)
-  result.register(matcher)
+  result.register(pair.matcher)
+  result.register(pair.errorHandler)
 
 proc initJester*(
-  matcher: MatchProcSync, # TODO: Annoying nim bug: `MatchProc | MatchProcSync` doesn't work.
+  pair: MatchPairSync, # TODO: Annoying nim bug: `MatchPair | MatchPairSync` doesn't work.
   settings: Settings = newSettings()
 ): Jester =
   result = initJester(settings)
-  result.register(matcher)
+  result.register(pair.matcher)
+  result.register(pair.errorHandler)
 
 proc serve*(
   self: var Jester
@@ -1306,7 +1316,7 @@ proc routesEx(name: string, body: NimNode): NimNode =
         `afterRoutes`
   )
 
-  let matchIdent = newIdentNode(name)
+  let matchIdent = newIdentNode(name & "Matcher")
   let reqIdent = newIdentNode("request")
   let needsAsync = needsAsync(body)
   case needsAsync
@@ -1366,6 +1376,26 @@ proc routesEx(name: string, body: NimNode): NimNode =
     errorHandlerProc[6][0][1][^1][2][1][0] = stmts
   result.add(errorHandlerProc)
 
+  # Pair the matcher and error matcher
+  let pairIdent = newIdentNode(name)
+  let matchProcVarIdent = newIdentNode(name & "MatchProc")
+  let errorProcVarIdent = newIdentNode(name & "ErrorProc")
+  if needsAsync in {ImplicitTrue, ExplicitTrue}:
+    # TODO: I don't understand why I have to assign these procs to intermediate
+    # variables in order to get them into the tuple.  It would be nice if it could
+    # just be:
+    #   let `pairIdent`: MatchPair = (`matchIdent`, `errorHandlerIdent`)
+    result.add quote do:
+      let `matchProcVarIdent`: MatchProc = `matchIdent`
+      let `errorProcVarIdent`: ErrorProc = `errorHandlerIdent`
+      let `pairIdent`: MatchPair = (`matchProcVarIdent`, `errorProcVarIdent`)
+  else:
+    result.add quote do:
+      let `matchProcVarIdent`: MatchProcSync = `matchIdent`
+      let `errorProcVarIdent`: ErrorProc = `errorHandlerIdent`
+      let `pairIdent`: MatchPairSync = (`matchProcVarIdent`, `errorProcVarIdent`)
+  
+
   # TODO: Replace `body`, `headers`, `code` in routes with `result[i]` to
   # get these shortcuts back without sacrificing usability.
   # TODO2: Make sure you replace what `guessAction` used to do for this.
@@ -1376,13 +1406,11 @@ proc routesEx(name: string, body: NimNode): NimNode =
 macro routes*(body: untyped) =
   result = routesEx("match", body)
   let jesIdent = genSym(nskVar, "jes")
-  let matchIdent = newIdentNode("match")
-  let errorHandlerIdent = newIdentNode("matchErrorHandler")
+  let pairIdent = newIdentNode("match")
   let settingsIdent = newIdentNode("settings")
   result.add(
     quote do:
-      var `jesIdent` = initJester(`matchIdent`, `settingsIdent`)
-      `jesIdent`.register(`errorHandlerIdent`)
+      var `jesIdent` = initJester(`pairIdent`, `settingsIdent`)
   )
   result.add(
     quote do:

--- a/jester.nim
+++ b/jester.nim
@@ -477,6 +477,13 @@ proc initJester*(
   result.register(pair.matcher)
   result.register(pair.errorHandler)
 
+proc initJester*(
+  matcher: MatchProc,
+  settings: Settings = newSettings()
+): Jester =
+  result = initJester(settings)
+  result.register(matcher)
+
 proc serve*(
   self: var Jester
 ) =

--- a/jester.nim
+++ b/jester.nim
@@ -484,6 +484,13 @@ proc initJester*(
   result = initJester(settings)
   result.register(matcher)
 
+proc initJester*(
+  matcher: MatchProcSync,
+  settings: Settings = newSettings()
+): Jester =
+  result = initJester(settings)
+  result.register(matcher)
+
 proc serve*(
   self: var Jester
 ) =

--- a/tests/customRouter.nim
+++ b/tests/customRouter.nim
@@ -1,0 +1,20 @@
+import jester
+
+router myrouter:
+  get "/":
+    resp "Hello world"
+
+  get "/raise":
+    raise newException(Exception, "Foobar")
+
+  error Exception:
+    resp Http500, "Something bad happened: " & exception.msg
+
+when isMainModule:
+  let s = newSettings(
+    Port(5454),
+    bindAddr="127.0.0.1",
+  )
+  var jest = initJester(myrouter, s)
+  # jest.register(myrouterErrorHandler)
+  jest.serve()

--- a/tests/customRouter.nim
+++ b/tests/customRouter.nim
@@ -3,6 +3,9 @@ import jester
 router myrouter:
   get "/":
     resp "Hello world"
+  
+  get "/404":
+    resp "you got 404"
 
   get "/raise":
     raise newException(Exception, "Foobar")
@@ -10,11 +13,13 @@ router myrouter:
   error Exception:
     resp Http500, "Something bad happened: " & exception.msg
 
+  error Http404:
+    redirect uri("/404")
+
 when isMainModule:
   let s = newSettings(
     Port(5454),
     bindAddr="127.0.0.1",
   )
   var jest = initJester(myrouter, s)
-  # jest.register(myrouterErrorHandler)
   jest.serve()

--- a/tests/issue296.nim
+++ b/tests/issue296.nim
@@ -1,0 +1,12 @@
+# Note, this isn't ran as part of the test suite as it relies on randomness too much.
+
+import jester, asyncdispatch, random, logging
+
+setLogFilter(lvlInfo)
+routes:
+  before "/":
+    setLogFilter(lvlInfo)
+  get "/":
+    let dur = rand(2000)
+    await sleepAsync(dur)
+    resp "hi"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -264,6 +264,12 @@ proc customRouterTest(useStdLib: bool) =
       let body = (waitFor resp.body)
       checkpoint body
       check body.startsWith("Something bad happened: Foobar")
+    
+    test "redirect in error":
+      let resp = waitFor client.get(address & "/definitely404route")
+      check resp.code == Http303
+      check resp.headers["location"] == address & "/404"
+      check (waitFor resp.body) == ""
 
 when isMainModule:
   try:

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -253,12 +253,26 @@ proc issue150(useStdLib: bool) =
       check resp.code == Http500
       check (waitFor resp.body).startsWith("Something bad happened")
 
+proc customRouterTest(useStdLib: bool) =
+  waitFor startServer("customRouter.nim", useStdLib)
+  var client = newAsyncHttpClient(maxRedirects = 0)
+
+  suite "customRouter useStdLib=" & $useStdLib:
+    test "error handler":
+      let resp = waitFor client.get(address & "/raise")
+      check resp.code == Http500
+      let body = (waitFor resp.body)
+      checkpoint body
+      check body.startsWith("Something bad happened: Foobar")
+
 when isMainModule:
   try:
     allTest(useStdLib=false) # Test HttpBeast.
     allTest(useStdLib=true)  # Test asynchttpserver.
     issue150(useStdLib=false)
     issue150(useStdLib=true)
+    customRouterTest(useStdLib=false)
+    customRouterTest(useStdLib=true)
 
     # Verify that Nim in Action Tweeter still compiles.
     test "Nim in Action - Tweeter":


### PR DESCRIPTION
Fixes #269 (includes #267 because it relies on the testing changes included there)

`nimble test` doesn't work for me because of some of the other dependencies failing (as noted in #263), but I've tested the change and seen the added test pass.