### PR TITLE
Specify number of threads to be used by httpbeast

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -499,7 +499,7 @@ proc serve*(
       proc (req: httpbeast.Request): Future[void] =
          {.gcsafe.}:
           result = handleRequest(jes, req),
-      httpbeast.initSettings(self.settings.port, self.settings.bindAddr)
+      httpbeast.initSettings(self.settings.port, self.settings.bindAddr, self.settings.numThreads)
     )
   else:
     self.httpServer = newAsyncHttpServer(reusePort=self.settings.reusePort)

--- a/jester/private/utils.nim
+++ b/jester/private/utils.nim
@@ -17,6 +17,8 @@ type
     bindAddr*: string
     reusePort*: bool
     futureErrorHandler*: proc (fut: Future[void]) {.closure, gcsafe.}
+    when useHttpBeast:
+      numThreads*: int
 
   JesterError* = object of Exception
 

--- a/jester/private/utils.nim
+++ b/jester/private/utils.nim
@@ -17,8 +17,7 @@ type
     bindAddr*: string
     reusePort*: bool
     futureErrorHandler*: proc (fut: Future[void]) {.closure, gcsafe.}
-    when useHttpBeast:
-      numThreads*: int
+    numThreads*: int # Only available with Httpbeast (`useHttpBeast = true`)
 
   JesterError* = object of Exception
 


### PR DESCRIPTION
This PR adds a new setting to specify the number threads when compiled with `useHttpBeast`.

Solves #233 and allows the user to define the number of threads `httpBeast` may use when it is initiated from within `jester`.

**Example**
```nim
# specify_threads.nim
import jester

settings:
  bindAddr    = "127.0.0.1"
  port        = Port(5040)
  numThreads  = 3

routes:
  get "/":
    resp "threads"
```
```bash
$ nim c -r specify_threads.nim
INFO Jester is making jokes at http://127.0.0.1:5040
Starting 3 threads
Listening on port 5040
```
