### PR TITLE
Allow setHeader and resp with headers to be used in the same handler

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -14,6 +14,7 @@ export request
 export strtabs
 export tables
 export httpcore
+export options
 export MultiData
 export HttpMethod
 export asyncdispatch
@@ -565,7 +566,7 @@ template resp*(code: HttpCode,
                content: string): typed =
   ## Sets ``(code, headers, content)`` as the response.
   bind TCActionSend
-  result = (TCActionSend, code, none[RawHeaders](), content, true)
+  result = (TCActionSend, code, result[2], content, true)
   for header in headers:
     setHeader(result[2], header[0], header[1])
   break route
@@ -752,6 +753,8 @@ template uri*(address = "", absolute = true, addScriptName = true): untyped =
 
 template responseHeaders*(): var ResponseHeaders =
   ## Access the Option[RawHeaders] response headers
+  if result[2].isNone:
+    result[2] = some[RawHeaders](@[])
   result[2]
 
 proc daysForward*(days: int): DateTime =

--- a/tests/alltest.nim
+++ b/tests/alltest.nim
@@ -223,3 +223,8 @@ routes:
 
   get "/issue157":
     resp(Http200, [("Content-Type","text/css")] , "foo")
+  
+  get "/manyheaders":
+    setHeader(responseHeaders, "foo", "foo")
+    setHeader(responseHeaders, "bar", "bar")
+    resp Http200, {"Content-Type": "text/plain"}, "result"

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -154,6 +154,13 @@ proc allTest(useStdLib: bool) =
     let resp = waitFor client.get(address & "/foo/issue157")
     let headers = resp.headers
     check headers["Content-Type"] == "text/css"
+  
+  test "resp doesn't overwrite headers":
+    let resp = waitFor client.get(address & "/foo/manyheaders")
+    let headers = resp.headers
+    check headers["foo"] == "foo"
+    check headers["bar"] == "bar"
+    check headers["Content-Type"] == "text/plain"
 
   suite "static":
     test "index.html":


### PR DESCRIPTION
Supersedes #294 with the minimal change needed to accomplish the fix.