### PR TITLE
Allow binding to IPv6 address

### DIFF
--- a/jester/request.nim
+++ b/jester/request.nim
@@ -1,6 +1,6 @@
 import uri, cgi, tables, logging, strutils, re, options
 
-import jester/private/utils
+import private/utils
 
 when useHttpBeast:
   import httpbeast except Settings


### PR DESCRIPTION
Closes #303 

Example here can be accessed at http://[::1]:8080
```nim
import asyncdispatch, jester, os, strutils

router myrouter:
  get "/":
    resp "It's alive!"

proc main() =
  let port = 8080.Port
  let settings = newSettings(port=port, bindAddr="::1")
  var jester = initJester(myrouter, settings=settings)
  jester.serve()

main()
```

Does this by parsing the passed `bindAddr` and seeing if its a IPv4 or 6 address (defaults to IPv4)