### PR TITLE
Expose asynchttpserver maxBody setting

### DIFF
--- a/jester.nim
+++ b/jester.nim
@@ -420,7 +420,7 @@ proc handleRequest(jes: Jester, httpReq: NativeRequest): Future[void] =
 
 proc newSettings*(
   port = Port(5000), staticDir = getCurrentDir() / "public",
-  appName = "", bindAddr = "", reusePort = false,
+  appName = "", bindAddr = "", reusePort = false, maxBody = 8388608,
   futureErrorHandler: proc (fut: Future[void]) {.closure, gcsafe.} = nil
 ): Settings =
   result = Settings(
@@ -429,6 +429,7 @@ proc newSettings*(
     port: port,
     bindAddr: bindAddr,
     reusePort: reusePort,
+    maxBody: maxBody,
     futureErrorHandler: futureErrorHandler
   )
 
@@ -530,7 +531,7 @@ proc serve*(
       httpbeast.initSettings(self.settings.port, self.settings.bindAddr, self.settings.numThreads)
     )
   else:
-    self.httpServer = newAsyncHttpServer(reusePort=self.settings.reusePort)
+    self.httpServer = newAsyncHttpServer(reusePort=self.settings.reusePort, maxBody=self.settings.maxBody)
     let serveFut = self.httpServer.serve(
       self.settings.port,
       proc (req: asynchttpserver.Request): Future[void] {.gcsafe, closure.} =

--- a/jester/private/utils.nim
+++ b/jester/private/utils.nim
@@ -16,6 +16,7 @@ type
     port*: Port
     bindAddr*: string
     reusePort*: bool
+    maxBody*: int
     futureErrorHandler*: proc (fut: Future[void]) {.closure, gcsafe.}
     numThreads*: int # Only available with Httpbeast (`useHttpBeast = true`)
 


### PR DESCRIPTION
Right now, Jester can't handle a post body larger than 8MB if [asynchttpserver](https://nim-lang.org/docs/asynchttpserver.html) is used.

This is a configurable setting (`maxBody`) in newAsyncHttpServer, yet it is not currently exposed in the settings object. This PR adds `maxBody` to the settings object and passes it on to newAsyncHttpServer when serve is called.

The default value ( 8388608 ) is directly taken from the asynchttpserver docs.