### PR TITLE
Decode all URL params no matter what

### DIFF
--- a/changelog.markdown
+++ b/changelog.markdown
@@ -2,7 +2,7 @@
 
 ## 0.6.0 - ??/07/2021
 
-- **Breaking change:** the `@` operator used for retrieving request parameters now automatically decodes special characters using `decodeUrl`.
+- **Breaking change:** All request parameters are automatically decoded using `decodeUrl`. Accessing the parameters with the `@` operator or directly through the raw `request.params` returns the value decoded.
 - Fix for [#211](https://github.com/dom96/jester/issues/211) - custom routers now have the same error handling as normal routes.
 - Fix for [#269](https://github.com/dom96/jester/issues/269) - a bug that prevented redirecting from within error handlers.
 

--- a/jester.nim
+++ b/jester.nim
@@ -700,7 +700,7 @@ template `@`*(s: string): untyped =
     # TODO: Why does request.params not work? :(
     # TODO: This is some weird bug with macros/templates, I couldn't
     # TODO: reproduce it easily.
-    decodeUrl(params(request)[s])
+    params(request)[s]
   else:
     ""
 

--- a/jester/request.nim
+++ b/jester/request.nim
@@ -105,7 +105,7 @@ proc params*(req: Request): Table[string, string] =
 
   try:
     for key, val in cgi.decodeData(query):
-      result[key] = val
+      result[key] = decodeUrl(val)
   except CgiError:
     logging.warn("Incorrect query. Got: $1" % [query])
 


### PR DESCRIPTION
This fixes issue https://github.com/dom96/jester/issues/312.

**Base**
_Request to roll back commit https://github.com/dom96/jester/commit/a03b5be0b72f1a686b6ca594c145cee665e6db7b which implemented PR https://github.com/dom96/jester/pull/171 which fixed Issue https://github.com/dom96/jester/issues/159._

**Description**
Instead of a rollback of the previous commit, since that solves some problems, this commit fixes the bug which was introduces for non-URL params. We were already decoding non-URL parameters, the previous commit implemented a "double decode".

To fix this we now just decode all params on init. It adds a little overhead, but using `benchy` it doesn't look that bad.