### PR TITLE
Add startup callback to settings for httpbeast

### DIFF
--- a/jester/private/utils.nim
+++ b/jester/private/utils.nim
@@ -19,6 +19,7 @@ type
     maxBody*: int
     futureErrorHandler*: proc (fut: Future[void]) {.closure, gcsafe.}
     numThreads*: int # Only available with Httpbeast (`useHttpBeast = true`)
+    startup*: proc () {.closure, gcsafe.} # Only available with Httpbeast (`useHttpBeast = true`)
 
   JesterError* = object of Exception
 


### PR DESCRIPTION
Hi Dom,

A follow-up PR from the httpbeast PR https://github.com/dom96/httpbeast/pull/89 :)

- This PR implements the `startup` proc in Jester' settings, which then is passed on to httpbeast. The `startup` proc will run in each httpbeast-thread at initialization.
- As is, this PR only implements the `startup` proc to be used, when jester is running with httpbeast.
- The concept for "only allowing" with httpbeast follows the previous `numThreads` implementation.

Would this be a possible PR? Or are there any changes you would like to see?