### PR TITLE
Add startup callback to settings for httpbeast + fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         nimversion:
         - 1.4.8
-        - git:6b97889f44d06f66
+        - 1.6.0
         os:
         - ubuntu-latest
         - macOS-latest
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v1
       with:
         submodules: true
-    - uses: iffy/install-nim@v3.2.0
+    - uses: iffy/install-nim@v4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        nimversion: ${{ matrix.nimversion }}
+        version: ${{ matrix.nimversion }}
     - name: Test
       run: |
         nimble test

--- a/jester/private/utils.nim
+++ b/jester/private/utils.nim
@@ -19,6 +19,7 @@ type
     maxBody*: int
     futureErrorHandler*: proc (fut: Future[void]) {.closure, gcsafe.}
     numThreads*: int # Only available with Httpbeast (`useHttpBeast = true`)
+    startup*: proc () {.closure, gcsafe.} # Only available with Httpbeast (`useHttpBeast = true`)
 
   JesterError* = object of Exception
 


### PR DESCRIPTION
**Notes:**

- Previous PR https://github.com/dom96/jester/pull/318 was closed due to deleted branch in fork.. mistake.
- This PR also includes the CI fix specified by iffy and available as independent PR https://github.com/dom96/jester/pull/319

___

Hi Dom,

A follow-up PR from the httpbeast PR https://github.com/dom96/httpbeast/pull/89 :)

- This PR implements the `startup` proc in Jester' settings, which then is passed on to httpbeast. The `startup` proc will run in each httpbeast-thread at initialization.
- As is, this PR only implements the `startup` proc to be used, when jester is running with httpbeast.
- The concept for "only allowing" with httpbeast follows the previous `numThreads` implementation.

Would this be a possible PR? Or are there any changes you would like to see?