### PR TITLE
Add support for duplicate keys in parameters by adding `paramValuesAsSeq`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         nimversion:
-#        - 1.4.8
-#        - 1.6.14
+        - 1.4.8
+        - 1.6.14
         - 2.0.0
         os:
         - ubuntu-latest
@@ -32,5 +32,4 @@ jobs:
       run: |
         nimble --version
         nimble refresh -y
-        nimble setup
         nimble test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,4 +30,7 @@ jobs:
         version: ${{ matrix.nimversion }}
     - name: Test
       run: |
+        nimble --version
+        nimble refresh -y
+        nimble setup
         nimble test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
         nimversion:
         - 1.4.8
         - 1.6.14
+        - 2.0.0
         os:
         - ubuntu-latest
         - macOS-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,10 @@ jobs:
         - macOS-latest
         - windows-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: iffy/install-nim@v3.2.0
+    - uses: iffy/install-nim@v4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         nimversion:
         - 1.4.8
-        - git:6b97889f44d06f66
+        - 1.6.14
         os:
         - ubuntu-latest
         - macOS-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ jobs:
         nimversion:
         - 1.4.8
         - 1.6.14
-        - 2.0.0
         os:
         - ubuntu-latest
         - macOS-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        nimversion: ${{ matrix.nimversion }}
+        version: ${{ matrix.nimversion }}
     - name: Test
       run: |
         nimble test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         nimversion:
-        - 1.4.8
-        - 1.6.14
+#        - 1.4.8
+#        - 1.6.14
         - 2.0.0
         os:
         - ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,4 +31,3 @@ jobs:
     - name: Test
       run: |
         nimble test
-        nimble refresh

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 !/tests/*/
 
 nimcache
+
+.idea/
+*.iml

--- a/jester.nimble
+++ b/jester.nimble
@@ -16,5 +16,7 @@ when not defined(windows):
   requires "httpbeast >= 0.4.0"
 
 task test, "Runs the test suite.":
+  when NimMajor < 2:
+    exec "git submodule update --init"
   exec "nimble install -y asynctools@#0e6bdc3ed5bae8c7cc9"
   exec "nim c -r tests/tester"

--- a/jester.nimble
+++ b/jester.nimble
@@ -18,7 +18,7 @@ when not defined(windows):
 task test, "Runs the test suite.":
   when NimMajor < 2:
     exec "git submodule update --init"
-  exec "nimble refresh"
-  exec "nimble install"
+  exec "nimble refresh -y"
+  exec "nimble install -y"
   exec "nimble install -y asynctools@#0e6bdc3ed5bae8c7cc9"
   exec "nim c -r tests/tester"

--- a/jester.nimble
+++ b/jester.nimble
@@ -23,5 +23,3 @@ task test, "Runs the test suite.":
   exec "nimble install -y asynctools@#0e6bdc3ed5bae8c7cc9"
   when NimMajor < 2:
     exec "nim c -r tests/tester"
-  when NimMajor >= 2:
-    exec "nim c --mm:refc --run tests/tester"

--- a/jester.nimble
+++ b/jester.nimble
@@ -21,4 +21,7 @@ task test, "Runs the test suite.":
   exec "nimble refresh -y"
   exec "nimble install -y"
   exec "nimble install -y asynctools@#0e6bdc3ed5bae8c7cc9"
-  exec "nim c -r tests/tester"
+  when NimMajor < 2:
+    exec "nim c -r tests/tester"
+  when NimMajor >= 2:
+    exec "nim c --mm:refc --run tests/tester"

--- a/jester.nimble
+++ b/jester.nimble
@@ -18,5 +18,7 @@ when not defined(windows):
 task test, "Runs the test suite.":
   when NimMajor < 2:
     exec "git submodule update --init"
+  exec "nimble refresh"
+  exec "nimble install"
   exec "nimble install -y asynctools@#0e6bdc3ed5bae8c7cc9"
   exec "nim c -r tests/tester"

--- a/jester.nimble
+++ b/jester.nimble
@@ -21,5 +21,4 @@ task test, "Runs the test suite.":
   exec "nimble refresh -y"
   exec "nimble install -y"
   exec "nimble install -y asynctools@#0e6bdc3ed5bae8c7cc9"
-  when NimMajor < 2:
-    exec "nim c -r tests/tester"
+  exec "nim c -r tests/tester"

--- a/jester/request.nim
+++ b/jester/request.nim
@@ -1,4 +1,5 @@
 import uri, cgi, tables, logging, strutils, re, options
+from sequtils import map
 
 import jester/private/utils
 
@@ -115,6 +116,41 @@ proc params*(req: Request): Table[string, string] =
       parseUrlQuery(req.body, result)
     except:
       logging.warn("Could not parse URL query.")
+
+proc paramValuesAsSeq*(req: Request): Table[string, seq[string]] =
+  ## Parameters from the pattern and the query string.
+  ##
+  ## This allows for duplicated keys in the query (in contrast to `params`)
+  if req.patternParams.isSome():
+    let patternParams: Table[string, string] = req.patternParams.get()
+    var patternParamsSeq: seq[(string, string)] = @[]
+    for key, val in pairs(patternParams):
+      patternParamsSeq.add (key, val)
+
+    # We are not url-decoding the key/value for the patternParams (matches implementation in `params`
+    result = sequtils.map(patternParamsSeq,
+              proc(entry: (string, string)): (string, seq[string]) =
+                (entry[0], @[entry[1]])
+    ).toTable()
+  else:
+    result = initTable[string, seq[string]]()
+
+  var queriesToDecode: seq[string] = @[]
+  queriesToDecode.add query(req)
+
+  let contentType = req.headers.getOrDefault("Content-Type")
+  if contentType.startswith("application/x-www-form-urlencoded"):
+    queriesToDecode.add req.body
+
+  for query in queriesToDecode:
+    try:
+      for key, value in cgi.decodeData(query):
+        if result.hasKey(key):
+          result[key].add value
+        else:
+          result[key] = @[value]
+    except CgiError:
+      logging.warn("Incorrect query. Got: $1" % [query])
 
 proc formData*(req: Request): MultiData =
   let contentType = req.headers.getOrDefault("Content-Type")

--- a/tests/issue247.nim
+++ b/tests/issue247.nim
@@ -1,0 +1,41 @@
+from std/cgi import decodeUrl
+from std/strformat import fmt
+from std/strutils import join
+import jester
+
+settings:
+  port = Port(5454)
+  bindAddr = "127.0.0.1"
+
+proc formatParams(params: Table[string, string]): string =
+  result = ""
+  for key, value in params.pairs:
+    result.add fmt"{key}: {value}"
+
+proc formatSeqParams(params: Table[string, seq[string]]): string =
+  result = ""
+  for key, values in params.pairs:
+    let value = values.join ","
+    result.add fmt"{key}: {value}"
+
+routes:
+  get "/":
+    resp Http200
+  get "/params":
+    let params = params request
+    resp formatParams params
+  get "/params/@val%23ue":
+    let params = params request
+    resp formatParams params
+  post "/params/@val%23ue":
+    let params = params request
+    resp formatParams params
+  get "/multi":
+    let params = paramValuesAsSeq request
+    resp formatSeqParams(params)
+  get "/@val%23ue":
+    let params = paramValuesAsSeq request
+    resp formatSeqParams(params)
+  post "/@val%23ue":
+    let params = paramValuesAsSeq request
+    resp formatSeqParams(params)

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -287,9 +287,11 @@ when isMainModule:
     customRouterTest(useStdLib=false)
     customRouterTest(useStdLib=true)
 
-    # Verify that Nim in Action Tweeter still compiles.
-    test "Nim in Action - Tweeter":
-      let path = "tests/nim-in-action-code/Chapter7/Tweeter/src/tweeter.nim"
-      check execCmd("nim c --path:. " & path) == QuitSuccess
+    # nim-in-action Chapter7 is not compatible with nim >= 2.0
+    when NimMajor < 2:
+      # Verify that Nim in Action Tweeter still compiles.
+      test "Nim in Action - Tweeter":
+        let path = "tests/nim-in-action-code/Chapter7/Tweeter/src/tweeter.nim"
+        check execCmd("nim c --path:. " & path) == QuitSuccess
   finally:
     doAssert execCmd("kill -15 " & $serverProcess.processID()) == QuitSuccess

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -271,12 +271,107 @@ proc customRouterTest(useStdLib: bool) =
       let body = (waitFor resp.body)
       checkpoint body
       check body.startsWith("Something bad happened: Foobar")
-    
+
     test "redirect in error":
       let resp = waitFor client.get(address & "/definitely404route")
       check resp.code == Http303
       check resp.headers["location"] == address & "/404"
       check (waitFor resp.body) == ""
+
+proc issue247(useStdLib: bool) =
+  waitFor startServer("issue247.nim", useStdLib)
+  var client = newAsyncHttpClient(maxRedirects = 0)
+
+  suite "issue247 useStdLib=" & $useStdLib:
+    test "duplicate keys in query":
+      let resp = waitFor client.get(address & "/multi?a=1&a=2")
+      check (waitFor resp.body) == "a: 1,2"
+
+    test "no duplicate keys in query":
+      let resp = waitFor client.get(address & "/multi?a=1")
+      check (waitFor resp.body) == "a: 1"
+
+    test "assure that empty values are handled":
+      let resp = waitFor client.get(address & "/multi?a=1&a=")
+      check (waitFor resp.body) == "a: 1,"
+
+    test "assure that fragment is not parsed":
+      let resp = waitFor client.get(address & "/multi?a=1&#a=2")
+      check (waitFor resp.body) == "a: 1"
+
+    test "ensure that values are url decoded per default":
+      let resp = waitFor client.get(address & "/multi?a=1&a=1%232")
+      check (waitFor resp.body) == "a: 1,1#2"
+
+    test "ensure that keys are url decoded per default":
+      let resp = waitFor client.get(address & "/multi?a%23b=1&a%23b=1%232")
+      check (waitFor resp.body) == "a#b: 1,1#2"
+
+    test "test different keys":
+      let resp = waitFor client.get(address & "/multi?a=1&b=2")
+      check (waitFor resp.body) == "b: 2a: 1"
+
+    test "ensure that path params aren't escaped":
+      let resp = waitFor client.get(address & "/hello%23world")
+      check (waitFor resp.body) == "val%23ue: hello%23world"
+
+    test "test path params and query":
+      let resp = waitFor client.get(address & "/hello%23world?a%23+b=1%23+b")
+      check (waitFor resp.body) == "a# b: 1# bval%23ue: hello%23world"
+
+    test "test percent encoded path param and query param (same key)":
+      let resp = waitFor client.get(address & "/hello%23world?val%23ue=1%23+b")
+      check (waitFor resp.body) == "val%23ue: hello%23worldval#ue: 1# b"
+
+    test "test path param, query param and x-www-form-urlencoded":
+      client.headers = newHttpHeaders({"Content-Type": "application/x-www-form-urlencoded"})
+      let resp = waitFor client.post(address & "/hello%23world?val%23ue=1%23+b", "val%23ue=1%23+b&b=2")
+      check (waitFor resp.body) == "val%23ue: hello%23worldb: 2val#ue: 1# b,1# b"
+
+    test "params duplicate keys in query":
+      let resp = waitFor client.get(address & "/params?a=1&a=2")
+      check (waitFor resp.body) == "a: 2"
+
+    test "params no duplicate keys in query":
+      let resp = waitFor client.get(address & "/params?a=1")
+      check (waitFor resp.body) == "a: 1"
+
+    test "params assure that empty values are handled":
+      let resp = waitFor client.get(address & "/params?a=1&a=")
+      check (waitFor resp.body) == "a: "
+
+    test "params assure that fragment is not parsed":
+      let resp = waitFor client.get(address & "/params?a=1&#a=2")
+      check (waitFor resp.body) == "a: 1"
+
+    test "params ensure that values are url decoded per default":
+      let resp = waitFor client.get(address & "/params?a=1&a=1%232")
+      check (waitFor resp.body) == "a: 1#2"
+
+    test "params ensure that keys are url decoded per default":
+      let resp = waitFor client.get(address & "/params?a%23b=1&a%23b=1%232")
+      check (waitFor resp.body) == "a#b: 1#2"
+
+    test "params test different keys":
+      let resp = waitFor client.get(address & "/params?a=1&b=2")
+      check (waitFor resp.body) == "b: 2a: 1"
+
+    test "params ensure that path params aren't escaped":
+      let resp = waitFor client.get(address & "/params/hello%23world")
+      check (waitFor resp.body) == "val%23ue: hello%23world"
+
+    test "params test path params and query":
+      let resp = waitFor client.get(address & "/params/hello%23world?a%23+b=1%23+b")
+      check (waitFor resp.body) == "a# b: 1# bval%23ue: hello%23world"
+
+    test "params test percent encoded path param and query param (same key)":
+      let resp = waitFor client.get(address & "/params/hello%23world?val%23ue=1%23+b")
+      check (waitFor resp.body) == "val#ue: 1# bval%23ue: hello%23world"
+
+    test "params test path param, query param and x-www-form-urlencoded":
+      client.headers = newHttpHeaders({"Content-Type": "application/x-www-form-urlencoded"})
+      let resp = waitFor client.post(address & "/params/hello%23world?val%23ue=1%23+b", "val%23ue=1%23+b&b=2")
+      check (waitFor resp.body) == "b: 2val#ue: 1# bval%23ue: hello%23world"
 
 when isMainModule:
   try:
@@ -286,6 +381,8 @@ when isMainModule:
     issue150(useStdLib=true)
     customRouterTest(useStdLib=false)
     customRouterTest(useStdLib=true)
+    issue247(useStdLib=false)
+    issue247(useStdLib=true)
 
     # nim-in-action Chapter7 is not compatible with nim >= 2.0
     when NimMajor < 2:

--- a/tests/tester.nim
+++ b/tests/tester.nim
@@ -154,7 +154,7 @@ proc allTest(useStdLib: bool) =
     let resp = waitFor client.get(address & "/foo/issue157")
     let headers = resp.headers
     check headers["Content-Type"] == "text/css"
-  
+
   test "resp doesn't overwrite headers":
     let resp = waitFor client.get(address & "/foo/manyheaders")
     let headers = resp.headers


### PR DESCRIPTION
Closes #247

I've implemented an example solution (new function) so that we can discuss further based on this.

I've opened this as a draft PR since the actual implementation discussion is not really relevant for the issue itself.

I'm sorry to say that I'm still not entirely sure how [the following would work](https://github.com/dom96/jester/issues/247#issuecomment-1722790239):

> My suggestion was for a way to do it without changing jester-code, but just hooking in on available fields = the .url

I'm still fairly new to nim (<1000 lines) so forgive me if I'm missing something obvious here, the only options I see to implement this are

- experimental features (e.g. `dotOperators`)
- adding a `url` property (new type?) to `Request` which supports this feature (this modifies code even further though and would be inconsistent with the current implementation)
- probably templates/macros similar to promoting a `proc` to a different implementation when explicitely called by the user (or the library)
- implementing this for both `httpbeast` and the standard library and expose this via jester (also needs code changes since the `NativeRequest` isn't exposed to the user) (also unlikely to be accepted)

That being said, this should probably be a separate function in any case which can be used by any of the other options if another shortcut/accessor is implemented for this.

I'm not entirely happy with the name (feel free to suggest others) but I hope it's at least clear enough on what it does.

I've removed the explicit call to `decodeUrl(value)` (in both `params` and `paramValuesAsSeq`) since `decodeData` (`decodeQuery` internally) does the decoding for us already.

#### `parseUrlQuery`

I've also updated the `params` function to not use `parseUrlQuery` anymore since this has been marked as deprecated in any case.

With this change the 2 function operate essentially the same exact way (excluding the return type).

I haven't removed it since it's exported and might be used by users.

#### Tests

I've also implemented some tests for both `params` and `paramValuesAsSeq` (exactly the same tests with different results).

I tested this against the old version of `params` and the new version.

#### CI

##### os

Currently the CI:

- fails on windows
  - I don't really have access to a windows machine right now and have no idea what the problem could be
- aborts on mac due to the runner coming up late
- succeeds on linux

##### versions

CI succeeds for nim 1.4.8 and 1.6.14, for nim 2 the CI throws a `SIGSEGV: Illegal storage access. (Attempt to read from nil?)`.

I've observed this behaviour with jester before and either running nim with `--mm:refc` or importing `std/segfaults` fixed this (which is very frustrating).

I've only tested running with `--mm:refc` which didn't fix it in the CI, I didn't want to import `std/segfaults` in all tests only for the CI to work since this is obviously a bug somewhere.

I haven't looked into this any closer though, everything (tests + jester itself) run fine for me with nim 2.0 (locally and in docker).

---

Comments on things I've updated which aren't directly related to the issue. I hope including this here is fine with you, otherwise I don't mind pulling these changes out and opening a separate PR with them.

#### Exclude testing `tests/nim-in-action-code` for `nim >= 2.0`

[nim-in-action-code](https://github.com/dom96/nim-in-action-code/) isn't trying to be compatible with nim 2 (as far as I can tell).

The compilation currently fails because `db_sqlite` [isn't available anymore](https://nim-lang.org/docs/db_sqlite.html) (needs a `nimble install db_connector` and a change of import, i.e. -> `db_connector/db_sqlite`

#### Update the CI

Basically this #319, I didn't want a broken CI when submitting a PR.

#### Update `nimble test`

Up to now the user had to execute some steps themselves (e.g. refresh/install), `nimble test` should now work without any further input from the user after cloning the repository.

#### .gitignore

I've developed with intellij so I've added the common ignores for this IDE
