### PR TITLE
Updated README Request type

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -159,7 +159,7 @@ Request* = ref object
                                 ## instead.
   headers*: StringTableRef      ## Headers received with the request.
                                 ## Retrieving these is case insensitive.
-  formData*: TMultiData         ## Form data; only present for
+  formData*: MultiData          ## Form data; only present for
                                 ## multipart/form-data
   port*: int
   host*: string
@@ -172,8 +172,8 @@ Request* = ref object
   query*: string                ## Query string of request.
   cookies*: StringTableRef      ## Cookies from the browser.
   ip*: string                   ## IP address of the requesting client.
-  reqMeth*: TReqMeth            ## Request method, eg. HttpGet, HttpPost
-  settings*: PSettings
+  reqMeth*: HttpMethod          ## Request method, eg. HttpGet, HttpPost
+  settings*: Settings
 ```
 
 ## Examples
@@ -211,4 +211,3 @@ routes:
     var push = parseJson(@"payload")
     resp "I got some JSON: " & $push
 ```
-


### PR DESCRIPTION
Seems like some field types in the Request object were changed in the code but not in the README.